### PR TITLE
feat: play/pause by tapping on spacebar

### DIFF
--- a/frontend/components/StationPlayer.tsx
+++ b/frontend/components/StationPlayer.tsx
@@ -17,6 +17,7 @@ import {CONSTANTS} from '../lib/constants';
 import {Loading} from '@/public/images/loading';
 import {ImageWithFallback} from '@/components/ImageWithFallback/ImageWithFallback';
 import Hls from 'hls.js';
+import useSpaceBarPress from '@/hooks/useSpaceBarPress';
 
 enum STREAM_TYPE {
   HLS = 'HLS',
@@ -225,6 +226,20 @@ export default function StationPlayer({stations}: any) {
     }, 30 * 1000);
     return () => clearInterval(timer);
   }, [playbackState]);
+
+  useSpaceBarPress(() => {
+    if (
+      playbackState === PLAYBACK_STATE.PLAYING ||
+      playbackState === PLAYBACK_STATE.STARTED
+    ) {
+      setPlaybackState(PLAYBACK_STATE.STOPPED);
+      return;
+    }
+
+    if (playbackState === PLAYBACK_STATE.STOPPED) {
+      setPlaybackState(PLAYBACK_STATE.STARTED);
+    }
+  });
 
   const nextRandomStation = () => {
     const upStations = stations.filter(

--- a/frontend/hooks/useSpaceBarPress.ts
+++ b/frontend/hooks/useSpaceBarPress.ts
@@ -1,0 +1,25 @@
+import {useEffect} from 'react';
+
+const useSpaceBarPress = (callback: any) => {
+  useEffect(() => {
+    window.addEventListener('keydown', function (e) {
+      if (e.keyCode == 32 && e.target == document.body) {
+        e.preventDefault();
+      }
+    });
+
+    const handleKeyPress = (e: any) => {
+      if (e.key === ' ' || e.code === 'Space' || e.keyCode === 32) {
+        callback();
+      }
+    };
+
+    document.body.addEventListener('keyup', handleKeyPress);
+
+    return () => {
+      document.body.removeEventListener('keyup', handleKeyPress);
+    };
+  }, [callback]);
+};
+
+export default useSpaceBarPress;

--- a/frontend/hooks/useSpaceBarPress.ts
+++ b/frontend/hooks/useSpaceBarPress.ts
@@ -3,16 +3,28 @@ import {useEffect} from 'react';
 const useSpaceBarPress = (callback: any) => {
   useEffect(() => {
     const handleKeyDown = (e: any) => {
+      const isInputOrTextArea = ['input', 'textarea', 'select'].includes(
+        e.target.tagName.toLowerCase(),
+      );
+
       if (
         e.keyCode === 32 &&
-        e.target.getAttribute('contentEditable') !== 'true'
+        e.target.getAttribute('contentEditable') !== 'true' &&
+        !isInputOrTextArea
       ) {
         e.preventDefault();
       }
     };
 
     const handleKeyPress = (e: any) => {
-      if (e.key === ' ' || e.code === 'Space' || e.keyCode === 32) {
+      const isInputOrTextArea = ['input', 'textarea', 'select'].includes(
+        e.target.tagName.toLowerCase(),
+      );
+
+      if (
+        (e.key === ' ' || e.code === 'Space' || e.keyCode === 32) &&
+        !isInputOrTextArea
+      ) {
         callback();
       }
     };

--- a/frontend/hooks/useSpaceBarPress.ts
+++ b/frontend/hooks/useSpaceBarPress.ts
@@ -2,11 +2,14 @@ import {useEffect} from 'react';
 
 const useSpaceBarPress = (callback: any) => {
   useEffect(() => {
-    window.addEventListener('keydown', function (e) {
-      if (e.keyCode == 32 && e.target == document.body) {
+    const handleKeyDown = (e: any) => {
+      if (
+        e.keyCode === 32 &&
+        e.target.getAttribute('contentEditable') !== 'true'
+      ) {
         e.preventDefault();
       }
-    });
+    };
 
     const handleKeyPress = (e: any) => {
       if (e.key === ' ' || e.code === 'Space' || e.keyCode === 32) {
@@ -15,9 +18,11 @@ const useSpaceBarPress = (callback: any) => {
     };
 
     document.body.addEventListener('keyup', handleKeyPress);
+    document.body.addEventListener('keydown', handleKeyDown);
 
     return () => {
       document.body.removeEventListener('keyup', handleKeyPress);
+      document.body.removeEventListener('keydown', handleKeyDown);
     };
   }, [callback]);
 };

--- a/frontend/hooks/useSpaceBarPress.ts
+++ b/frontend/hooks/useSpaceBarPress.ts
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
 
-const useSpaceBarPress = (callback: any) => {
+const useSpaceBarPress = (callback: () => void) => {
   useEffect(() => {
     const handleKeyDown = (e: any) => {
       const isInputOrTextArea = ['input', 'textarea', 'select'].includes(


### PR DESCRIPTION
Left to do:
- [x] for preventing the browser to scroll down on tapping space I think we should move the following code in _document.tsx
```
    window.addEventListener('keydown', function (e) {
      if (e.keyCode == 32 && e.target == document.body) {
        e.preventDefault();
      }
    });
```
- [x] add removeEventListener on keydown event